### PR TITLE
Fix build on Java 9

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -226,9 +226,15 @@
     <echo message="Debug:         ${debug}" />
   </target>
 
-  <target name="init" depends="configure">
-    <requirejar property="tools.jar" />
+  <condition property="needs-tools-jar">
+    <matches pattern="1\.[5678].*" string="${ant.java.version}"/>
+  </condition>
 
+  <target name="check-tools-jar" if="needs-tools-jar">
+    <requirejar property="tools.jar" />
+  </target>
+
+  <target name="init" depends="configure,check-tools-jar">
     <tstamp />
     <condition property="cofoja.version"
                value="${version}-${DSTAMP}"

--- a/ivy.xml
+++ b/ivy.xml
@@ -12,7 +12,7 @@
     <artifact name="cofoja+contracts" conf="contracts" />
   </publications>
   <dependencies>
-    <dependency org="org.ow2.asm" name="asm-all" rev="5.+" conf="*->default" />
+    <dependency org="org.ow2.asm" name="asm-all" rev="6.+" conf="*->default" />
     <dependency org="junit" name="junit-dep" rev="[3.8,)" conf="test->default" />
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
The Java 9 release doesn't require you to add `tools.jar` to the classpath to access most of the `tools.jar` classes. In fact, `tools.jar` doesn't even exist: https://stackoverflow.com/a/35244168/1216956

This pull request fixes the build system to only check for `tools.jar` on Java 1.5-1.8, not on 9. (I don't normally do `ant`; I don't know if there's a better way.)

Additionally, ASM5 does not work on Java 9. Switch to ASM6, currently in beta.

After this change, the build and tests complete successfully.